### PR TITLE
[Refactor] ResponseEntity를 사용하여 클라이언트에 보내는 응답 제어

### DIFF
--- a/src/main/java/com/eun0/schedulerdevelop/controller/CommentController.java
+++ b/src/main/java/com/eun0/schedulerdevelop/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.eun0.schedulerdevelop.dto.comment.CommentResponse;
 import com.eun0.schedulerdevelop.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,22 +18,44 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping("")
-    public CommentResponse createComment(@RequestParam Long userId, @PathVariable Long scheduleId, @RequestBody @Valid CommentRequest requestDto) {
-        return commentService.createComment(userId, scheduleId, requestDto);
+    public  ResponseEntity<CommentResponse> createComment(
+            @RequestParam Long userId,
+            @PathVariable Long scheduleId,
+            @RequestBody @Valid CommentRequest requestDto
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(commentService.createComment(userId, scheduleId, requestDto));
     }
 
     @GetMapping("")
-    public List<CommentResponse> readAllCommentsByScheduleId(@PathVariable Long scheduleId) {
-        return commentService.readAllCommentsByScheduleId(scheduleId);
+    public  ResponseEntity<List<CommentResponse>> readAllCommentsByScheduleId(
+            @PathVariable Long scheduleId
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(commentService.readAllCommentsByScheduleId(scheduleId));
     }
 
     @PutMapping("/{commentId}")
-    public CommentResponse updateComment(@PathVariable Long scheduleId, @PathVariable Long commentId, @RequestBody @Valid CommentRequest requestDto) {
-        return commentService.updateComment(scheduleId, commentId, requestDto);
+    public  ResponseEntity<CommentResponse> updateComment(
+            @PathVariable Long scheduleId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid CommentRequest requestDto
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(commentService.updateComment(scheduleId, commentId, requestDto));
     }
 
     @DeleteMapping("/{commentId}")
-    public void deleteComment(@PathVariable Long scheduleId, @PathVariable Long commentId) {
+    public  ResponseEntity<Void> deleteComment(
+            @PathVariable Long scheduleId,
+            @PathVariable Long commentId
+    ) {
         commentService.deleteComment(scheduleId, commentId);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 }

--- a/src/main/java/com/eun0/schedulerdevelop/controller/ScheduleController.java
+++ b/src/main/java/com/eun0/schedulerdevelop/controller/ScheduleController.java
@@ -7,6 +7,8 @@ import com.eun0.schedulerdevelop.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,34 +18,53 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping("")
-    public ScheduleResponse createSchedule(@RequestBody @Valid ScheduleRequest requestDto, @RequestParam Long userId) {
-        return scheduleService.createSchedule(requestDto, userId);
+    public ResponseEntity<ScheduleResponse> createSchedule(
+            @RequestBody @Valid ScheduleRequest requestDto,
+            @RequestParam Long userId) {
+        ScheduleResponse responseDto = scheduleService.createSchedule(requestDto, userId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(responseDto);
     }
 
     @GetMapping("/{scheduleId}")
-    public ScheduleResponse readSchedule(@PathVariable Long scheduleId) {
-        return scheduleService.readSchedule(scheduleId);
+    public ResponseEntity<ScheduleResponse> readSchedule(
+            @PathVariable Long scheduleId
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(scheduleService.readSchedule(scheduleId));
     }
 
     @GetMapping("")
-    public Page<SchedulePagingResponse> readSchedulesAsPageSize(
+    public ResponseEntity<Page<SchedulePagingResponse>> readSchedulesAsPageSize(
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "10") int size
     ) {
-        return scheduleService.readSchedulesAsPageSize(page, size);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(scheduleService.readSchedulesAsPageSize(page, size));
     }
 
     @PutMapping("/{scheduleId}")
-    public ScheduleResponse updateSchedule(
+    public ResponseEntity<ScheduleResponse> updateSchedule(
             @PathVariable Long scheduleId,
             @RequestBody @Valid ScheduleRequest requestDto,
             @RequestParam Long userId
     ) {
-        return scheduleService.updateSchedule(scheduleId, requestDto, userId);
+        return ResponseEntity
+                .status(HttpStatus.RESET_CONTENT)
+                .body(scheduleService.updateSchedule(scheduleId, requestDto, userId));
     }
 
     @DeleteMapping("/{scheduleId}")
-    public void deleteSchedule(@PathVariable Long scheduleId, @RequestParam Long userId) {
+    public ResponseEntity<Void> deleteSchedule(
+            @PathVariable Long scheduleId,
+            @RequestParam Long userId
+    ) {
         scheduleService.deleteSchedule(scheduleId, userId);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 }

--- a/src/main/java/com/eun0/schedulerdevelop/controller/UserController.java
+++ b/src/main/java/com/eun0/schedulerdevelop/controller/UserController.java
@@ -6,6 +6,8 @@ import com.eun0.schedulerdevelop.dto.user.UserUpdateRequest;
 import com.eun0.schedulerdevelop.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -15,23 +17,41 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public UserResponse signup(@RequestBody @Valid SignupRequest requestDto) {
-        return userService.signup(requestDto);
+    public ResponseEntity<UserResponse> signup(
+            @RequestBody @Valid SignupRequest requestDto
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(userService.signup(requestDto));
     }
 
     @GetMapping("/{userId}")
-    public UserResponse findUserById(@PathVariable("userId") Long id) {
-        return userService.findUserById(id);
+    public ResponseEntity<UserResponse> findUserById(
+            @PathVariable("userId") Long id
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(userService.findUserById(id));
     }
 
     @PutMapping("/{userId}")
-    public UserResponse updateUser(@PathVariable("userId") Long id, @RequestBody @Valid UserUpdateRequest requestDto) {
-        return userService.updateUser(id, requestDto);
+    public ResponseEntity<UserResponse> updateUser(
+            @PathVariable("userId") Long id,
+            @RequestBody @Valid UserUpdateRequest requestDto
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.RESET_CONTENT)
+                .body(userService.updateUser(id, requestDto));
     }
 
     @DeleteMapping("/{userId}")
-    public void deleteUser(@PathVariable("userId") Long id) {
+    public ResponseEntity<Void> deleteUser(
+            @PathVariable("userId") Long id
+    ) {
         userService.deleteUser(id);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
     }
 
 }


### PR DESCRIPTION
Issue #1 

### 목적
- 클라이언트에 보내는 HTTP 응답 제어
- 상세한 에러 메시지 전달 → 예외 처리 강화

### 구현 방법
HttpEntity 클래스를 상속받아 구현한 ResponseEntity 클래스 사용

### ResponseEntity 사용 방법
- 빌더 패턴 사용
- method chaining으로 연결한 빌더 패턴을 사용함으로써, 더 직관적이고 유지 보수에 용이
- ResponseEntity의 Body 타입 명시